### PR TITLE
Enable php templating inside script tag

### DIFF
--- a/src/optionsFromVsCode.ts
+++ b/src/optionsFromVsCode.ts
@@ -55,6 +55,7 @@ export default function(config) {
     html: {
       end_with_newline: config.html.format.endWithNewline,
       js: {
+        templating: "php",
         end_with_newline: false
       }
     }


### PR DESCRIPTION
In jsbeautifier templating is turned on by default in HTML and turned off by default in JavaScript.

PHP templating inside javascript script tags needs to be enabled explicitly. 

Fixes #46
Fixes #37
Fixes #31